### PR TITLE
Fix PHP 7.2 error: 

### DIFF
--- a/src/services/ElementImporter.php
+++ b/src/services/ElementImporter.php
@@ -370,7 +370,7 @@ class ElementImporter extends Component
             }
         }
 
-        if (count($newElements) && is_array($newElements)) {
+        if (is_array($newElements) && count($newElements)) {
             try {
                 foreach ($newElements as $row) {
                     $importerClass = SproutBase::$app->importers->getImporter($row);


### PR DESCRIPTION
count(): "Parameter must be an array or an object that implements Countable"